### PR TITLE
Switch phpcs from WordPress to Docs and Extra rules

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,8 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="WordPress" />
+    <rule ref="WordPress-Docs" />
+    <rule ref="WordPress-Extra" />
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />


### PR DESCRIPTION
As per this manual:
https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#standards-subsets

Using slightly less pedantic rulesets, to avoid errors, warninsg
and suggestions, which are related to the WordPress VIP.