### PR TITLE
Coding styles fixes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,10 +9,14 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="PSR2" />
+    <rule ref="WordPress-Docs" />
+    <rule ref="WordPress-Extra" />
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />
+
+    <!-- Added WordPress Coding Standards (wpcs) to path -->
+    <config name="installed_paths" value="../../wp-coding-standards/wpcs" />
 
     <!-- Assume UTF-8 -->
     <config name="encoding" value="UTF-8" />
@@ -24,8 +28,8 @@
     <arg value="p" />
 
     <!-- Files and directories to check -->
-    <file>./webroot/custom-themes/</file>
     <file>./src/</file>
     <file>./tests/</file>
+    <file>./webroot/custom-themes/</file>
     <file>./Phakefile.php</file>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,7 +29,5 @@
 
     <!-- Files and directories to check -->
     <file>./src/</file>
-    <file>./tests/</file>
     <file>./webroot/custom-themes/</file>
-    <file>./Phakefile.php</file>
 </ruleset>

--- a/webroot/custom-themes/custom/functions.php
+++ b/webroot/custom-themes/custom/functions.php
@@ -14,13 +14,13 @@
  */
 
 // Define theme's images URI.
-if (! defined('IMAGES_URI')) {
-    define('IMAGES_URI', get_stylesheet_directory_uri() . '/images/');
+if ( ! defined( 'IMAGES_URI' ) ) {
+	define( 'IMAGES_URI', get_stylesheet_directory_uri() . '/images/' );
 }
 
 // Define theme's functions directory.
-if (! defined('THEME_LIB_DIR')) {
-    define('THEME_LIB_DIR', __DIR__ . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR);
+if ( ! defined( 'THEME_LIB_DIR' ) ) {
+	define( 'THEME_LIB_DIR', __DIR__ . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR );
 }
 
 /**
@@ -29,16 +29,15 @@ if (! defined('THEME_LIB_DIR')) {
  * @param string $dir Directory to load files from.
  * @return void
  */
-function load_includes($dir)
-{
-    $it = new RecursiveDirectoryIterator($dir);
-    $it = new RecursiveIteratorIterator($it);
-    $it = new RegexIterator($it, '#.php$#');
-    foreach ($it as $include) {
-        if ($include->isReadable()) {
-            require_once($include->getPathname());
-        }
-    }
+function load_includes( $dir ) {
+	$it = new RecursiveDirectoryIterator( $dir );
+	$it = new RecursiveIteratorIterator( $it );
+	$it = new RegexIterator( $it, '#.php$#' );
+	foreach ( $it as $include ) {
+		if ( $include->isReadable() ) {
+			require_once( $include->getPathname() );
+		}
+	}
 }
 
-load_includes(THEME_LIB_DIR);
+load_includes( THEME_LIB_DIR );

--- a/webroot/custom-themes/custom/lib/functions/debug.php
+++ b/webroot/custom-themes/custom/lib/functions/debug.php
@@ -14,13 +14,12 @@
  * @param mixed $var Variable to print out.
  * @return void
  */
-function debug($var)
-{
-    if (defined('WP_DEBUG') && WP_DEBUG) {
-        echo '<pre>';
+function debug( $var ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		echo '<pre>';
 		// @codingStandardsIgnoreStart
 		print_r( $var );
 		// @codingStandardsIgnoreEnd
-        echo '</pre>';
-    }
+		echo '</pre>';
+	}
 }

--- a/webroot/custom-themes/custom/lib/functions/enqueue-parent-theme-style.php
+++ b/webroot/custom-themes/custom/lib/functions/enqueue-parent-theme-style.php
@@ -8,14 +8,13 @@
  * @subpackage Custom
  */
 
-add_action('wp_enqueue_scripts', 'enqueue_parent_theme_style');
+add_action( 'wp_enqueue_scripts', 'enqueue_parent_theme_style' );
 
 /**
  * Enqueue the CSS of the parent theme
  *
  * @return void
  */
-function enqueue_parent_theme_style()
-{
-    wp_enqueue_style('parent-style', get_template_directory_uri() . '/style.css');
+function enqueue_parent_theme_style() {
+	wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
 }

--- a/webroot/custom-themes/custom/lib/functions/require-login.php
+++ b/webroot/custom-themes/custom/lib/functions/require-login.php
@@ -13,13 +13,12 @@
  *
  * @return void
  */
-function redirect_non_logged_users_to_login_page()
-{
-    if (getenv('REQUIRE_LOGIN')) {
-        global $pagenow;
-        if (! is_user_logged_in() && 'wp-login.php' !== $pagenow) {
-            wp_safe_redirect(wp_login_url());
-        }
-    }
+function redirect_non_logged_users_to_login_page() {
+	if ( getenv( 'REQUIRE_LOGIN' ) ) {
+		global $pagenow;
+		if ( ! is_user_logged_in() && 'wp-login.php' !== $pagenow ) {
+			wp_safe_redirect( wp_login_url() );
+		}
+	}
 }
-add_action('wp', 'redirect_non_logged_users_to_login_page');
+add_action( 'wp', 'redirect_non_logged_users_to_login_page' );


### PR DESCRIPTION
* Revert rules back to WordPress Coding Style (overwritten by PSR-2 from project-template merge)
* Skip `tests/` and `Phakefile.php` from coding style checks as those don't matter and WP is too pedantic.
* Fixed (automatically, with `phpcbf`) some CS issues in `webroot/custom-themes/`