### PR TITLE
Replaced pushd/popd with cd alternatives (task #3523)

### DIFF
--- a/etc/wp-cli.install
+++ b/etc/wp-cli.install
@@ -51,12 +51,12 @@ done
 #
 # TODO: This should configurable and synchronized with wp-config.php
 echo "Creating symbolic link for custom theme in WordPress themes"
-pushd ./webroot/wp-content/themes > /dev/null
+cd ./webroot/wp-content/themes
 if [ ! -e custom ]
 then
 	ln -s ../../custom-themes/custom
 fi
-popd > /dev/null
+cd -
 
 #
 # Activate custom child theme themes

--- a/etc/wp-cli.update
+++ b/etc/wp-cli.update
@@ -19,12 +19,12 @@
 #
 # TODO: This should configurable and synchronized with wp-config.php
 echo "Creating symbolic link for custom theme in WordPress themes"
-pushd ./webroot/wp-content/themes > /dev/null
+cd ./webroot/wp-content/themes
 if [ ! -e custom ]
 then
 	ln -s ../../custom-themes/custom
 fi
-popd > /dev/null
+cd -
 
 # Install all plugins that are found in the Child theme directory.
 # Usually, these plugins are the proprietary plugins. (WPML, etc.).


### PR DESCRIPTION
`pushd` and `popd` are not available in the shell in BitBucket
Pipelines, so they are replaced now with a simpler `cd` alternatives