### PR TITLE
Specifying bash to execute commands #122

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,7 @@ CHOWN_USER=nginx
 CHGRP_PATH=webroot/wp-content
 CHGRP_GROUP=nginx
 
-
+SYSTEM_COMMAND_SHELL=/bin/bash
 WP_CHILD_PLUGIN_FOLDER=webroot/custom-themes/custom/plugins
 
 REQUIRE_LOGIN=0

--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,6 @@ CHOWN_USER=nginx
 CHGRP_PATH=webroot/wp-content
 CHGRP_GROUP=nginx
 
-SYSTEM_COMMAND_SHELL=/bin/bash
 WP_CHILD_PLUGIN_FOLDER=webroot/custom-themes/custom/plugins
 
 REQUIRE_LOGIN=0

--- a/Phakefile.php
+++ b/Phakefile.php
@@ -38,7 +38,7 @@ function runWPCLIBatch($name, $app)
     }
 
     $parts = array();
-    $parts[] = getValue('SYSTEM_COMMAND_SHELL', $app) ?: '/bin/sh';
+    $parts[] = getValue('SYSTEM_COMMAND_SHELL', $app) ?: '/bin/bash';
     $parts[] = $dst;
     doShellCommand($parts);
     unlink($dst);


### PR DESCRIPTION
Once triggered /bin/sh <script>.sh via phake builder, on Debian/Ubuntu environments it'll use `dash` but in RedHat it'll be using default `bash`.