### PR TITLE
Bugfix for WP_CONTENT_URL const to be full URL (task #3915)

### DIFF
--- a/webroot/wp-config.php
+++ b/webroot/wp-config.php
@@ -29,7 +29,7 @@ define('WP_SITEURL', WP_HOME . '/wp');
 
 // Changes for wp-content/ folder at root level
 define('WP_CONTENT_DIR', dirname(__FILE__) . '/wp-content');
-define('WP_CONTENT_URL', '/wp-content');
+define('WP_CONTENT_URL', WP_HOME . '/wp-content');
 
 $name = getenv('DB_NAME');
 $host = getenv('DB_HOST') ?: 'localhost';


### PR DESCRIPTION
* Changed WP_CONTENT_URL from /wp-content to WP_HOME/wp-content
  as it should be. That fixes problem with smart slider license activation