### PR TITLE
Update uk-cookie-consent to v2.3.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "wpackagist-plugin/restricted-site-access": "^7.0.1",
         "wpackagist-plugin/shortcodes-ultimate": "5.4.1",
         "wpackagist-plugin/tiny-compress-images": "3.2.0",
-        "wpackagist-plugin/uk-cookie-consent": "2.3.14",
+        "wpackagist-plugin/uk-cookie-consent": "2.3.15",
         "wpackagist-plugin/wordpress-seo": "12.0",
         "wpackagist-plugin/wp-media-library-categories": "1.7",
         "wpackagist-plugin/wp-super-cache": "1.7.0",


### PR DESCRIPTION
It looks like v2.3.14 has been removed and it's no longer available. This moves the package to the next patch available, resolving this issue #344 .